### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/promitazure/94182ede-9590-4ba8-850f-2524ba467450/6d54544c-af1e-4d35-ae70-a91b44539a46/_apis/work/boardbadge/66b3fd4c-3814-4d30-9635-7db344098d17)](https://dev.azure.com/promitazure/94182ede-9590-4ba8-850f-2524ba467450/_boards/board/t/6d54544c-af1e-4d35-ae70-a91b44539a46/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#22](https://dev.azure.com/promitazure/94182ede-9590-4ba8-850f-2524ba467450/_workitems/edit/22). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.